### PR TITLE
[Setting] #4 - Color Asset 추가

### DIFF
--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyBg.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyBg.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyBlack.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyBlack.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x14",
+          "green" : "0x14",
+          "red" : "0x18"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyBlue10.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyBlue10.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF4",
+          "green" : "0x9B",
+          "red" : "0x51"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyBlue20.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyBlue20.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC3",
+          "green" : "0x69",
+          "red" : "0x1E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyGray10.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyGray10.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB3",
+          "green" : "0xB3",
+          "red" : "0xB3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyGray20.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyGray20.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAD",
+          "green" : "0xAD",
+          "red" : "0xAD"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyGray30.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyGray30.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA7",
+          "green" : "0xA7",
+          "red" : "0xA7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyGray40.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyGray40.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x29",
+          "green" : "0x29",
+          "red" : "0x29"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyGreen.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyGreen.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x60",
+          "green" : "0xD7",
+          "red" : "0x1E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyLime.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyLime.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7A",
+          "green" : "0xF2",
+          "red" : "0xCA"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyPink.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyPink.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA2",
+          "green" : "0x73",
+          "red" : "0xF6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyPupple.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyPupple.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC8",
+          "green" : "0x9B",
+          "red" : "0xB4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyRed.colorset/Contents.json
+++ b/Spotify-iOS/Spotify-iOS/Global/Resource/Assets.xcassets/spotifyRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xC5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Test]: 테스트 코드 작성
[Merge]: merge

-->

## 💌 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
-  ColorAsset 추가
-  네이밍을 피그마에 있는 색상 이름과 다르게 설정함. 색상 이름 형식: spotify(colorName) 

## 💭 PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
- spotifyBg는 background 색상입니당
- Figma에 green 색상이 두 개가 있는데 라임색 같은 것을 spotifyLime으로 네이밍 했습니당. 
- 나중에 컬러 이름 바뀌면 반영해서 수정할게용


## 📷 스크린샷

<!-- 작업한 화면이 있다면 GIF 스크린 샷으로 첨부해주세요. -->
<!-- <img src = "이미지주소" width = "50%" height = "50%"> -->

|    작업 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/NOW-SOPT-APP9-SPOTIFY/Spotify_iOS/assets/65494460/d5d617a0-f3cb-4980-beee-d90a67765f11" width ="250">|

## 💐 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #4 
