### PR TITLE
[Fix] #20 - progress bar 화면에 안 뜨는 문제 해결

### DIFF
--- a/Spotify-iOS/Spotify-iOS/Presentation/Cells/MusicItemCollectionViewCell.swift
+++ b/Spotify-iOS/Spotify-iOS/Presentation/Cells/MusicItemCollectionViewCell.swift
@@ -24,7 +24,11 @@ class MusicItemCollectionViewCell: UICollectionViewCell {
     private let background = UIView()
     let gradientLayer = CAGradientLayer()
     private let musicTitle = UILabel()
-    lazy var progressBar = MusicProgressBarView() // 이걸 5개 반복해서 하면 될 듯
+    lazy var progressBar1 = MusicProgressBarView() // 이걸 5개 반복해서 하면 될 듯
+    lazy var progressBar2 = MusicProgressBarView()
+    lazy var progressBar3 = MusicProgressBarView()
+    lazy var progressBar4 = MusicProgressBarView()
+    lazy var progressBar5 = MusicProgressBarView()
     private let progressBarStackView = UIStackView()
     private lazy var muteButton = UIImageView()
     private let mainAlbumImage = UIView() // 서버 연결되면 UIImage로 교체
@@ -85,12 +89,39 @@ extension MusicItemCollectionViewCell {
             $0.numberOfLines = 1
         }
         
-        for _ in 0 ..< 5 { // 이게 되나...?
-            progressBar.do {
-                $0.backgroundColor = UIColor(red: 255, green: 255, blue: 255, alpha: 0.2)
-                progressBarStackView.addArrangedSubview(progressBar)
-            }
-            
+        progressBar1.do {
+            $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
+            $0.layer.cornerRadius = 2
+            $0.progress = 5
+            progressBarStackView.addArrangedSubview(progressBar1)
+        }
+        
+        progressBar2.do {
+            $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
+            $0.layer.cornerRadius = 2
+            $0.progress = 5
+            progressBarStackView.addArrangedSubview(progressBar2)
+        }
+        
+        progressBar3.do {
+            $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
+            $0.layer.cornerRadius = 2
+            $0.progress = 5
+            progressBarStackView.addArrangedSubview(progressBar3)
+        }
+        
+        progressBar4.do {
+            $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
+            $0.layer.cornerRadius = 2
+            $0.progress = 5
+            progressBarStackView.addArrangedSubview(progressBar4)
+        }
+        
+        progressBar5.do {
+            $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
+            $0.layer.cornerRadius = 2
+            $0.progress = 5
+            progressBarStackView.addArrangedSubview(progressBar5)
         }
         
         progressBarStackView.do {
@@ -183,11 +214,17 @@ extension MusicItemCollectionViewCell {
             $0.height.equalTo(14)
         }
         
-        progressBar.snp.makeConstraints {
+        progressBar1.snp.makeConstraints {
             $0.top.equalTo(musicTitle.snp.bottom).offset(6)
             $0.leading.equalTo(background.snp.leading).offset(15.91)
             $0.width.equalTo(54)
             $0.height.equalTo(4)
+        }
+        
+        progressBarStackView.snp.makeConstraints {
+            $0.top.equalTo(musicTitle.snp.bottom).offset(6)
+            $0.leading.equalTo(background.snp.leading).offset(15.91)
+            $0.width.equalTo(269)
         }
         
         muteButton.snp.makeConstraints {

--- a/Spotify-iOS/Spotify-iOS/Presentation/Cells/MusicItemCollectionViewCell.swift
+++ b/Spotify-iOS/Spotify-iOS/Presentation/Cells/MusicItemCollectionViewCell.swift
@@ -24,11 +24,11 @@ class MusicItemCollectionViewCell: UICollectionViewCell {
     private let background = UIView()
     let gradientLayer = CAGradientLayer()
     private let musicTitle = UILabel()
-    lazy var progressBar1 = MusicProgressBarView() // 이걸 5개 반복해서 하면 될 듯
-    lazy var progressBar2 = MusicProgressBarView()
-    lazy var progressBar3 = MusicProgressBarView()
-    lazy var progressBar4 = MusicProgressBarView()
-    lazy var progressBar5 = MusicProgressBarView()
+    lazy var progressBar1 = MusicProgressBarView(frame: CGRect(x: 0, y: 0, width: 52, height: 4))
+    lazy var progressBar2 = MusicProgressBarView(frame: CGRect(x: 0, y: 0, width: 52, height: 4))
+    lazy var progressBar3 = MusicProgressBarView(frame: CGRect(x: 0, y: 0, width: 52, height: 4))
+    lazy var progressBar4 = MusicProgressBarView(frame: CGRect(x: 0, y: 0, width: 52, height: 4))
+    lazy var progressBar5 = MusicProgressBarView(frame: CGRect(x: 0, y: 0, width: 52, height: 4))
     private let progressBarStackView = UIStackView()
     private lazy var muteButton = UIImageView()
     private let mainAlbumImage = UIView() // 서버 연결되면 UIImage로 교체
@@ -89,39 +89,12 @@ extension MusicItemCollectionViewCell {
             $0.numberOfLines = 1
         }
         
-        progressBar1.do {
-            $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
-            $0.layer.cornerRadius = 2
-            $0.progress = 5
-            progressBarStackView.addArrangedSubview(progressBar1)
-        }
-        
-        progressBar2.do {
-            $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
-            $0.layer.cornerRadius = 2
-            $0.progress = 5
-            progressBarStackView.addArrangedSubview(progressBar2)
-        }
-        
-        progressBar3.do {
-            $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
-            $0.layer.cornerRadius = 2
-            $0.progress = 5
-            progressBarStackView.addArrangedSubview(progressBar3)
-        }
-        
-        progressBar4.do {
-            $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
-            $0.layer.cornerRadius = 2
-            $0.progress = 5
-            progressBarStackView.addArrangedSubview(progressBar4)
-        }
-        
-        progressBar5.do {
-            $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
-            $0.layer.cornerRadius = 2
-            $0.progress = 5
-            progressBarStackView.addArrangedSubview(progressBar5)
+        [progressBar1,
+         progressBar2,
+         progressBar3,
+         progressBar4,
+         progressBar5].forEach {
+            self.progressBarStackView.addArrangedSubview($0)
         }
         
         progressBarStackView.do {
@@ -214,17 +187,11 @@ extension MusicItemCollectionViewCell {
             $0.height.equalTo(14)
         }
         
-        progressBar1.snp.makeConstraints {
-            $0.top.equalTo(musicTitle.snp.bottom).offset(6)
-            $0.leading.equalTo(background.snp.leading).offset(15.91)
-            $0.width.equalTo(54)
-            $0.height.equalTo(4)
-        }
-        
         progressBarStackView.snp.makeConstraints {
             $0.top.equalTo(musicTitle.snp.bottom).offset(6)
             $0.leading.equalTo(background.snp.leading).offset(15.91)
             $0.width.equalTo(269)
+            $0.height.equalTo(4)
         }
         
         muteButton.snp.makeConstraints {

--- a/Spotify-iOS/Spotify-iOS/Presentation/Views/Recommend/MusicProgressBarView.swift
+++ b/Spotify-iOS/Spotify-iOS/Presentation/Views/Recommend/MusicProgressBarView.swift
@@ -29,7 +29,9 @@ final class MusicProgressBarView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-//        setUI()
+        self.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
+        self.layer.cornerRadius = 2
+        self.frame = .init(x: 0, y: 0, width: 54, height: 4)
     }
     
     required init?(coder: NSCoder) {
@@ -46,4 +48,13 @@ extension MusicProgressBarView {
         let newWidth = self.bounds.width * progress
         musicProgressBar.frame.size.width = newWidth
     }
+    
+    func setLayout() {
+        musicProgressBar.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.height.equalTo(4)
+        }
+    }
+    
+    // update constraint
 }

--- a/Spotify-iOS/Spotify-iOS/Presentation/Views/Recommend/MusicProgressBarView.swift
+++ b/Spotify-iOS/Spotify-iOS/Presentation/Views/Recommend/MusicProgressBarView.swift
@@ -29,7 +29,7 @@ final class MusicProgressBarView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        setUI()
+//        setUI()
     }
     
     required init?(coder: NSCoder) {
@@ -46,13 +46,4 @@ extension MusicProgressBarView {
         let newWidth = self.bounds.width * progress
         musicProgressBar.frame.size.width = newWidth
     }
-    
-    func setUI() {
-        musicProgressBar.do { // progress bar 진행하는 건 일단 뷰 다 완성하고 나서 시도함.
-            $0.backgroundColor = UIColor(red: 173, green: 173, blue: 173, alpha: 1) // 이거 합세 파일에서는 .spotifyGray20하면 됨.
-            $0.layer.cornerRadius = 2
-            $0.frame = self.bounds
-        }
-    }
-    
 }

--- a/Spotify-iOS/Spotify-iOS/Presentation/Views/Recommend/MusicRecommendView.swift
+++ b/Spotify-iOS/Spotify-iOS/Presentation/Views/Recommend/MusicRecommendView.swift
@@ -21,7 +21,7 @@ class MusicRecommendView: UIView {
         musicRecommendationCollectionView.isScrollEnabled = true
         musicRecommendationCollectionView.backgroundColor = .clear
         musicRecommendationCollectionView.showsVerticalScrollIndicator = false
-            musicRecommendationCollectionView.isPagingEnabled = true
+    
         
         return musicRecommendationCollectionView
     }()

--- a/Spotify-iOS/Spotify-iOS/Presentation/Views/Recommend/MusicRecommendView.swift
+++ b/Spotify-iOS/Spotify-iOS/Presentation/Views/Recommend/MusicRecommendView.swift
@@ -21,6 +21,7 @@ class MusicRecommendView: UIView {
         musicRecommendationCollectionView.isScrollEnabled = true
         musicRecommendationCollectionView.backgroundColor = .clear
         musicRecommendationCollectionView.showsVerticalScrollIndicator = false
+            musicRecommendationCollectionView.isPagingEnabled = true
         
         return musicRecommendationCollectionView
     }()
@@ -53,14 +54,10 @@ class MusicRecommendView: UIView {
     func setLayout() {
         musicRecommendationCollectionView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(140)
-            $0.leading.equalToSuperview().offset(16)
-            $0.trailing.equalToSuperview().inset(16)
-            $0.width.equalTo(350)
-            $0.height.equalTo(1000)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview()
         }
-
     }
-    
 }
 
 // MARK: - Extensions
@@ -72,7 +69,7 @@ extension MusicRecommendView {
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                               heightDimension: .fractionalHeight(0.5))
+                                               heightDimension: .absolute(500))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
                                                        subitems: [item])
         


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Test]: 테스트 코드 작성
[Merge]: merge

-->

## 💌 작업한 내용
- [x] progress bar 화면에 뜨지 않는 문제 해결
- [x] 스크롤이 끝까지 되지 않았던 문제 해결

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 


## 💭 PR POINT
### MusicProgressBar가 화면에 뜨지 않는 문제해결 방법
#### 기존의 접근 방식 + 해결방법
MusicProgressBarView를 따로 분리해서 만들고 MusicCollectionViewCell에서 객체를 하나 만들고 이를 SetUI 함수에서 반복문을 이용해서 구현하려고 했는데 하나의 객체에 의존해서 만들다 보니까 여러개 만들었을 때 참조가 안되는 문제가 있어서 화면에 나타나지 않았어요. 
그래서 progressBar1, 2, 3, 4, 5를 만들고 이를 스택 뷰로 감싸서 구현했습니당. 코드 간략화 할 때 민서 형이 많은 도움을 줬어용(샤라웃 투 민서00~!)
``` swift
lazy var progressBar1 = MusicProgressBarView(frame: CGRect(x: 0, y: 0, width: 52, height: 4))
    lazy var progressBar2 = MusicProgressBarView(frame: CGRect(x: 0, y: 0, width: 52, height: 4))
    lazy var progressBar3 = MusicProgressBarView(frame: CGRect(x: 0, y: 0, width: 52, height: 4))
    lazy var progressBar4 = MusicProgressBarView(frame: CGRect(x: 0, y: 0, width: 52, height: 4))
    lazy var progressBar5 = MusicProgressBarView(frame: CGRect(x: 0, y: 0, width: 52, height: 4))
    private let progressBarStackView = UIStackView()

func setUI() {
        [progressBar1,
         progressBar2,
         progressBar3,
         progressBar4,
         progressBar5].forEach {
            self.progressBarStackView.addArrangedSubview($0)
        }
        
        progressBarStackView.do {
            $0.distribution = .fillEqually
            $0.axis = .horizontal
            $0.spacing = 3
        }
}

func setHierarchy() {
        addSubviews(
            background,
            musicTitle,
            progressBarStackView,
            muteButton,
            mainAlbumImage,
            subAlbumImage,
            albumName,
            musicianName,
            addPlaylistButton,
            optionButton,
            albumInfo,
            playButton
        )
}

func setLayout() {
        progressBarStackView.snp.makeConstraints {
            $0.top.equalTo(musicTitle.snp.bottom).offset(6)
            $0.leading.equalTo(background.snp.leading).offset(15.91)
            $0.width.equalTo(269)
            $0.height.equalTo(4)
        }
}
```
그리고 MusicProgressBarView()의 init에 설정되어야할 UI를 입력해줘서 Cell에서 귀찮게 UI작업을 또 해야하는 일을 없앴습니당
``` swift
// MusicProgressBarView() 내의 init 함수
override init(frame: CGRect) {
        super.init(frame: frame)
        
        self.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.2)
        self.layer.cornerRadius = 2
        self.frame = .init(x: 0, y: 0, width: 54, height: 4)
    }
```
### CollectionView에서 스크롤이 끝까지 되지 않았던 문제 해결방법
이건 정말 간단하게도... 내가 bottom margin을 주지 않았기 때문에 발생한 문제여따... 
``` swift
func setLayout() {
        musicRecommendationCollectionView.snp.makeConstraints {
            $0.top.equalToSuperview().offset(140)
            $0.horizontalEdges.equalToSuperview().inset(16)
            $0.bottom.equalToSuperview() // <- 요놈을 추가해서 해결!
        }
```
#### 플러스! 더 좋은 구조를 만들고 싶은 고민 
조언을 받으면서 하나 얘기가 나왔던 것이 만약에 progress bar의 게이지를 업데이트 시키고 싶다면 progress bar를 위한 뷰컨 파일을 따로 만들고 메인 뷰컨에 child로 붙이는 방법에 대한 이야기가 나왔습니다. 이를 통해서 progress bar와 관련된 기능을 구현하는데에 있어 함수도 분리되어있고 해서 구현하기 편할 것 같다고 생각했는데 솔직히 무슨 말인지는 알겠는데 있던 코드를 또 옮기려고 하니까 엄두가... ㅎㅎ 만약 전체적인 리펙토링을 한 번 한다면 그때 해봐도 좋을 것 같아용! 아직은 해야할게 많아서...(서버연결, 드롭다운, 드롭다운 이벤트 처리...🥲)
<!-- 덧붙이고 싶은 내용이 있다면! -->
-


## 📷 스크린샷

<!-- 작업한 화면이 있다면 GIF 스크린 샷으로 첨부해주세요. -->
<!-- <img src = "이미지주소" width = "50%" height = "50%"> -->

|    구현 내용    |   스크린샷 및 GIF   |
| :-------------: | :----------: |
| progress bar 문제 해결 | <img src = "https://github.com/NOW-SOPT-APP9-SPOTIFY/Spotify_iOS/assets/65494460/d7e2f9ce-727e-4e9b-9a31-44bcb8d6276f" width ="250">|
|Scroll 문제 해결|<img src = "https://github.com/NOW-SOPT-APP9-SPOTIFY/Spotify_iOS/assets/65494460/76979394-5d16-4567-8f43-6f8399ed954d" width ="250">|


## 💐 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #20 
